### PR TITLE
Changes to allow rapi transmission for DC relay enablement

### DIFF
--- a/src/openevse.cpp
+++ b/src/openevse.cpp
@@ -216,7 +216,7 @@ void OpenEVSEClass::setTime(tm &time, std::function<void(int ret)> callback)
 
 }
 
-void OpenEVSEClass::getChargeCurrentAndVoltage(std::function<void(int ret, double amps, double volts, int relay1, int relay2)> callback)
+void OpenEVSEClass::getChargeCurrentAndVoltage(std::function<void(int ret, double amps, double volts, int relay1, int relay2, int relayAC)> callback)
 {
   if (!_sender) {
     return;
@@ -237,13 +237,14 @@ void OpenEVSEClass::getChargeCurrentAndVoltage(std::function<void(int ret, doubl
         long milliVolts = strtol(_sender->getToken(2), NULL, 10);
         long rel1 = strtol(_sender->getToken(3), NULL, 10);
         long rel2 = strtol(_sender->getToken(4), NULL, 10);
+        long relAC = strtol(_sender->getToken(5), NULL, 10);
 
-        callback(ret, (double)milliAmps / 1000.0, (double)milliVolts / 1000.0, (int) rel1, (int) rel2);
+        callback(ret, (double)milliAmps / 1000.0, (double)milliVolts / 1000.0, (int) rel1, (int) rel2, (int) relAC);
       } else {
-        callback(RAPI_RESPONSE_INVALID_RESPONSE, 0, 0, 0, 0);
+        callback(RAPI_RESPONSE_INVALID_RESPONSE, 0, 0, 0, 0, 0);
       }
     } else {
-      callback(ret, 0, 0, 0, 0);
+      callback(ret, 0, 0, 0, 0, 0);
     }
   });
 }

--- a/src/openevse.cpp
+++ b/src/openevse.cpp
@@ -216,7 +216,7 @@ void OpenEVSEClass::setTime(tm &time, std::function<void(int ret)> callback)
 
 }
 
-void OpenEVSEClass::getChargeCurrentAndVoltage(std::function<void(int ret, double amps, double volts)> callback)
+void OpenEVSEClass::getChargeCurrentAndVoltage(std::function<void(int ret, double amps, double volts, int relay1, int relay2)> callback)
 {
   if (!_sender) {
     return;
@@ -235,13 +235,15 @@ void OpenEVSEClass::getChargeCurrentAndVoltage(std::function<void(int ret, doubl
       {
         long milliAmps = strtol(_sender->getToken(1), NULL, 10);
         long milliVolts = strtol(_sender->getToken(2), NULL, 10);
+        long rel1 = strtol(_sender->getToken(3), NULL, 10);
+        long rel2 = strtol(_sender->getToken(4), NULL, 10);
 
-        callback(ret, (double)milliAmps / 1000.0, (double)milliVolts / 1000.0);
+        callback(ret, (double)milliAmps / 1000.0, (double)milliVolts / 1000.0, (int) rel1, (int) rel2);
       } else {
-        callback(RAPI_RESPONSE_INVALID_RESPONSE, 0, 0);
+        callback(RAPI_RESPONSE_INVALID_RESPONSE, 0, 0, 0, 0);
       }
     } else {
-      callback(ret, 0, 0);
+      callback(ret, 0, 0, 0, 0);
     }
   });
 }

--- a/src/openevse.h
+++ b/src/openevse.h
@@ -130,7 +130,7 @@ class OpenEVSEClass
     void setTime(time_t time, std::function<void(int ret)> callback);
     void setTime(tm &time, std::function<void(int ret)> callback);
 
-    void getChargeCurrentAndVoltage(std::function<void(int ret, double amps, double volts)> callback);
+    void getChargeCurrentAndVoltage(std::function<void(int ret, double amps, double volts, int relay1, int relay2)> callback);
     void getTemperature(std::function<void(int ret, double temp1, bool temp1_valid, double temp2, bool temp2_valid, double temp3, bool temp3_valid)> callback);
     void getEnergy(std::function<void(int ret, double session, double total)> callback);
     void getFaultCounters(std::function<void(int ret, long gfci_count, long nognd_count, long stuck_count)> callback);

--- a/src/openevse.h
+++ b/src/openevse.h
@@ -130,7 +130,7 @@ class OpenEVSEClass
     void setTime(time_t time, std::function<void(int ret)> callback);
     void setTime(tm &time, std::function<void(int ret)> callback);
 
-    void getChargeCurrentAndVoltage(std::function<void(int ret, double amps, double volts, int relay1, int relay2)> callback);
+    void getChargeCurrentAndVoltage(std::function<void(int ret, double amps, double volts, int relay1, int relay2, int relayAC)> callback);
     void getTemperature(std::function<void(int ret, double temp1, bool temp1_valid, double temp2, bool temp2_valid, double temp3, bool temp3_valid)> callback);
     void getEnergy(std::function<void(int ret, double session, double total)> callback);
     void getFaultCounters(std::function<void(int ret, long gfci_count, long nognd_count, long stuck_count)> callback);


### PR DESCRIPTION
New to all of this but cars can accept single phase charging or 2/3 phase changing and this is to enable the sending of the 'enable' or 'disabled' state of the 2 DC relays that can be use to control 2 contractors for the phases.

This can be used for calculation of energy consumption.